### PR TITLE
fix(BBD 791): Triggering intermittently on less than 2 characters

### DIFF
--- a/src/search-box/index.ts
+++ b/src/search-box/index.ts
@@ -32,6 +32,7 @@ class SearchBox {
             this.actions.updateAutocompleteQuery(query);
           } else {
             this.flux.emit('sayt:hide');
+            this.actions.updateAutocompleteQuery('');
           }
       }
     },

--- a/test/unit/search-box.ts
+++ b/test/unit/search-box.ts
@@ -46,7 +46,9 @@ suite('SearchBox', ({ expect, spy, stub }) => {
       describe('onKeyUp()', () => {
         it('should set preventUpdate', () => {
           const event: any = { keyCode: 10, target: {} };
+          const updateAutocompleteQuery = spy();
           searchBox.flux = <any>{ emit: () => null };
+          searchBox.actions = <any>{ updateAutocompleteQuery };
 
           searchBox.state.onKeyUp(event);
 
@@ -95,11 +97,14 @@ suite('SearchBox', ({ expect, spy, stub }) => {
 
         it('should emit sayt:hide on blank query', () => {
           const emit = spy();
+          const updateAutocompleteQuery = spy();
           searchBox.flux = <any>{ emit };
+          searchBox.actions = <any>{ updateAutocompleteQuery };
 
           searchBox.state.onKeyUp(<any>{ target: {} });
 
           expect(emit).to.be.calledWith('sayt:hide');
+          expect(updateAutocompleteQuery).to.be.calledWith('');
         });
 
         it('should emit sayt:activate_next on arrow down pressed', () => {


### PR DESCRIPTION
Now emitting empty query if query invalid in order to clear.
Relies on https://github.com/groupby/flux-capacitor/pull/97
Another option would be to only send empty string if backspace was pressed and query falsy, however I went for the simpler option.