### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/search-box/index.ts
+++ b/src/search-box/index.ts
@@ -12,7 +12,7 @@ class SearchBox {
   $query: Query.State;
   refs: { searchBox: HTMLInputElement };
   state: SearchBox.State = {
-    originalQuery: Selectors.query(this.flux.store.getState()),
+    originalQuery: this.select(Selectors.query),
     onKeyDown: (event) => (event.keyCode === KEY_DOWN || event.keyCode === KEY_UP) && event.preventDefault(),
     onKeyUp: (event) => {
       event.preventUpdate = true;

--- a/test/unit/search-box.ts
+++ b/test/unit/search-box.ts
@@ -4,15 +4,14 @@ import SearchBox from '../../src/search-box';
 import suite from './_suite';
 
 const QUERY = 'blue dress';
-const STATE = { a: 'b' };
 
 suite('SearchBox', ({ expect, spy, stub }) => {
-  let querySelector: sinon.SinonStub;
+  let select: sinon.SinonSpy;
   let searchBox: SearchBox;
 
   beforeEach(() => {
-    querySelector = stub(Selectors, 'query').returns(QUERY);
-    SearchBox.prototype.flux = <any>{ store: { getState: () => STATE } };
+    select = SearchBox.prototype.select = spy(() => QUERY);
+    SearchBox.prototype.flux = <any>{};
     searchBox = new SearchBox();
   });
   afterEach(() => delete SearchBox.prototype.flux);
@@ -21,7 +20,7 @@ suite('SearchBox', ({ expect, spy, stub }) => {
     describe('state', () => {
       describe('originalQuery', () => {
         it('should set originalQuery from state', () => {
-          expect(querySelector).to.be.calledWith(STATE);
+          expect(select).to.be.calledWith(Selectors.query);
           expect(searchBox.state.originalQuery).to.eq(QUERY);
         });
       });


### PR DESCRIPTION
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
