### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/query/index.html
+++ b/src/query/index.html
@@ -1,5 +1,5 @@
 <yield>
   <gb-search-box></gb-search-box>
   <gb-submit></gb-submit>
-  <gb-sayt if="{ props.showSayt }"></gb-sayt>
+  <gb-sayt if="{props.showSayt}"></gb-sayt>
 </yield>

--- a/src/search-box/index.html
+++ b/src/search-box/index.html
@@ -1,3 +1,3 @@
 <yield>
-  <input ref="searchBox" type="text" placeholder="Search..." onclick="{ state.onClick }" onkeydown="{ state.onKeyDown }" onkeypress="{ state.onKeyDown }" onkeyup="{ state.onKeyUp }" value="{ state.originalQuery }" autofocus>
+  <input ref="searchBox" type="text" placeholder="Search..." onclick="{state.onClick}" onkeydown="{state.onKeyDown}" onkeypress="{state.onKeyDown}" onkeyup="{state.onKeyUp}" value="{state.originalQuery}" autofocus>
 </yield>

--- a/src/submit/index.html
+++ b/src/submit/index.html
@@ -1,3 +1,3 @@
 <yield>
-  <gb-link on-click="{ state.onClick }">&#128269;</gb-link>
+  <gb-link on-click="{state.onClick}">&#128269;</gb-link>
 </yield>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.